### PR TITLE
再実行を避けるために、データのキャッシュを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ cython_debug/
 output**/
 *.csv
 .DS_Store
+temp

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,200 @@
+# Below are all the sections and options you can have in ~/.streamlit/config.toml.
+
+[global]
+
+# By default, Streamlit checks if the Python watchdog module is available and, if not, prints a warning asking for you to install it. The watchdog module is not required, but highly recommended. It improves Streamlit's ability to detect changes to files in your filesystem.
+# If you'd like to turn off this warning, set this to True.
+# Default: false
+# disableWatchdogWarning = false
+
+# If True, will show a warning when you run a Streamlit-enabled script via "python my_script.py".
+# Default: true
+# showWarningOnDirectExecution = true
+
+# DataFrame serialization.
+# Acceptable values: - 'legacy': Serialize DataFrames using Streamlit's custom format. Slow but battle-tested. - 'arrow': Serialize DataFrames using Apache Arrow. Much faster and versatile.
+# Default: "arrow"
+# dataFrameSerialization = "arrow"
+
+
+[logger]
+
+# Level of logging: 'error', 'warning', 'info', or 'debug'.
+# Default: 'info'
+# level = "info"
+
+# String format for logging messages. If logger.datetimeFormat is set, logger messages will default to `%(asctime)s.%(msecs)03d %(message)s`. See [Python's documentation](https://docs.python.org/2.6/library/logging.html#formatter-objects) for available attributes.
+# Default: "%(asctime)s %(message)s"
+# messageFormat = "%(asctime)s %(message)s"
+
+
+[client]
+
+# Whether to enable st.cache.
+# Default: true
+# caching = true
+
+# If false, makes your Streamlit script not draw to a Streamlit app.
+# Default: true
+# displayEnabled = true
+
+# Controls whether uncaught app exceptions and deprecation warnings are displayed in the browser. By default, this is set to True and Streamlit displays app exceptions and associated tracebacks, and deprecation warnings, in the browser.
+# If set to False, an exception or deprecation warning will result in a generic message being shown in the browser, and exceptions, tracebacks, and deprecation warnings will be printed to the console only.
+# Default: true
+# showErrorDetails = true
+
+
+[runner]
+
+# Allows you to type a variable or string by itself in a single line of Python code to write it to the app.
+# Default: true
+# magicEnabled = true
+
+# Install a Python tracer to allow you to stop or pause your script at any point and introspect it. As a side-effect, this slows down your script's execution.
+# Default: false
+# installTracer = false
+
+# Sets the MPLBACKEND environment variable to Agg inside Streamlit to prevent Python crashing.
+# Default: true
+# fixMatplotlib = true
+
+# Run the Python Garbage Collector after each script execution. This can help avoid excess memory use in Streamlit apps, but could introduce delay in rerunning the app script for high-memory-use applications.
+# Default: true
+# postScriptGC = true
+
+# Handle script rerun requests immediately, rather than waiting for script execution to reach a yield point. This makes Streamlit much more responsive to user interaction, but it can lead to race conditions in apps that mutate session_state data outside of explicit session_state assignment statements.
+# Default: true
+# fastReruns = true
+
+# Raise an exception after adding unserializable data to Session State. Some execution environments may require serializing all data in Session State, so it may be useful to detect incompatibility during development, or when the execution environment will stop supporting it in the future.
+# Default: false
+# enforceSerializableSessionState = false
+
+
+[server]
+
+# List of folders that should not be watched for changes. This impacts both "Run on Save" and @st.cache.
+# Relative paths will be taken as relative to the current working directory.
+# Example: ['/home/user1/env', 'relative/path/to/folder']
+# Default: []
+# folderWatchBlacklist = []
+
+# Change the type of file watcher used by Streamlit, or turn it off completely.
+# Allowed values: * "auto" : Streamlit will attempt to use the watchdog module, and falls back to polling if watchdog is not available. * "watchdog" : Force Streamlit to use the watchdog module. * "poll" : Force Streamlit to always use polling. * "none" : Streamlit will not watch files.
+# Default: "auto"
+# fileWatcherType = "auto"
+
+# Symmetric key used to produce signed cookies. If deploying on multiple replicas, this should be set to the same value across all replicas to ensure they all share the same secret.
+# Default: randomly generated secret key.
+# cookieSecret = "17cb51e45374777703a746457537b30f41649774235c5815ed9a26c226b3420f"
+
+# If false, will attempt to open a browser window on start.
+# Default: false unless (1) we are on a Linux box where DISPLAY is unset, or (2) we are running in the Streamlit Atom plugin.
+# headless = false
+
+# Automatically rerun script when the file is modified on disk.
+# Default: false
+# runOnSave = false
+
+# The address where the server will listen for client and browser connections. Use this if you want to bind the server to a specific address. If set, the server will only be accessible from this address, and not from any aliases (like localhost).
+# Default: (unset)
+# address =
+
+# The port where the server will listen for browser connections.
+# Default: 8501
+# port = 8501
+
+# The base path for the URL where Streamlit should be served from.
+# Default: ""
+# baseUrlPath = ""
+
+# Enables support for Cross-Origin Resource Sharing (CORS) protection, for added security.
+# Due to conflicts between CORS and XSRF, if `server.enableXsrfProtection` is on and `server.enableCORS` is off at the same time, we will prioritize `server.enableXsrfProtection`.
+# Default: true
+# enableCORS = true
+
+# Enables support for Cross-Site Request Forgery (XSRF) protection, for added security.
+# Due to conflicts between CORS and XSRF, if `server.enableXsrfProtection` is on and `server.enableCORS` is off at the same time, we will prioritize `server.enableXsrfProtection`.
+# Default: true
+# enableXsrfProtection = true
+
+# Max size, in megabytes, for files uploaded with the file_uploader.
+# Default: 200
+maxUploadSize = 1024
+
+# Max size, in megabytes, of messages that can be sent via the WebSocket connection.
+# Default: 200
+# maxMessageSize = 200
+
+# Enables support for websocket compression.
+# Default: false
+# enableWebsocketCompression = false
+
+# Enable serving files from a `static` directory in the running app's directory.
+# Default: false
+# enableStaticServing = false
+
+# Server certificate file for connecting via HTTPS. Must be set at the same time as "server.sslKeyFile".
+# ['DO NOT USE THIS OPTION IN A PRODUCTION ENVIRONMENT. It has not gone through security audits or performance tests. For the production environment, we recommend performing SSL termination by the load balancer or the reverse proxy.']
+# sslCertFile =
+
+# Cryptographic key file for connecting via HTTPS. Must be set at the same time as "server.sslCertFile".
+# ['DO NOT USE THIS OPTION IN A PRODUCTION ENVIRONMENT. It has not gone through security audits or performance tests. For the production environment, we recommend performing SSL termination by the load balancer or the reverse proxy.']
+# sslKeyFile =
+
+
+[browser]
+
+# Internet address where users should point their browsers in order to connect to the app. Can be IP address or DNS name and path.
+# This is used to: - Set the correct URL for CORS and XSRF protection purposes. - Show the URL on the terminal - Open the browser
+# Default: "localhost"
+# serverAddress = "localhost"
+
+# Whether to send usage statistics to Streamlit.
+# Default: true
+# gatherUsageStats = true
+
+# Port where users should point their browsers in order to connect to the app.
+# This is used to: - Set the correct URL for CORS and XSRF protection purposes. - Show the URL on the terminal - Open the browser
+# Default: whatever value is set in server.port.
+# serverPort = 8501
+
+
+[mapbox]
+
+# Configure Streamlit to use a custom Mapbox token for elements like st.pydeck_chart and st.map. To get a token for yourself, create an account at https://mapbox.com. It's free (for moderate usage levels)!
+# Default: ""
+# token = ""
+
+
+[deprecation]
+
+# Set to false to disable the deprecation warning for the file uploader encoding.
+# Default: true
+# showfileUploaderEncoding = true
+
+# Set to false to disable the deprecation warning for using the global pyplot instance.
+# Default: true
+# showPyplotGlobalUse = true
+
+
+[theme]
+
+# The preset Streamlit theme that your custom theme inherits from. One of "light" or "dark".
+# base =
+
+# Primary accent color for interactive elements.
+# primaryColor =
+
+# Background color for the main content area.
+# backgroundColor =
+
+# Background color used for the sidebar and most interactive widgets.
+# secondaryBackgroundColor =
+
+# Color used for almost all text.
+# textColor =
+
+# Font family for all text in the app, except code blocks. One of "sans serif", "serif", or "monospace".
+# font =
+

--- a/app.py
+++ b/app.py
@@ -44,11 +44,11 @@ def main():
         distinct_frames = remove_similar_frames(frames_with_diff_edges)
 
         # For DEBUG
-        output_dir = 'output'
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
-        for i, frame in enumerate(distinct_frames):
-            save_frame_as_image(output_dir, frame, i)
+        # output_dir = 'output'
+        # if not os.path.exists(output_dir):
+        #     os.makedirs(output_dir)
+        # for i, frame in enumerate(distinct_frames):
+        #     save_frame_as_image(output_dir, frame, i)
 
         st.header("抽出画面")
         # Display the distinct frames in a grid format

--- a/app.py
+++ b/app.py
@@ -50,23 +50,27 @@ def main():
         # for i, frame in enumerate(distinct_frames):
         #     save_frame_as_image(output_dir, frame, i)
 
-        st.header("抽出画面")
-        # Display the distinct frames in a grid format
-        cols = st.columns(NUM_COLS)
-        # Allow user to select which frames to download
+        frames_selected = False
         selected_frames = []
-        for i, frame in enumerate(distinct_frames):
-            with cols[i % NUM_COLS]:
-                with st.container():
-                    st.image(frame, use_column_width=True, channels='BGR')
-                    if st.checkbox("👆", key=f'frame_{i}'):
-                        selected_frames.append(frame)
 
-        st.divider()
-        # Allow user to download the selected frames as JPEG files
-        if len(selected_frames) > 0:
-            zip_buffer = zip_images(selected_frames)
-            st.download_button(label='⬇️ 選択した画面をまとめてダウンロード', data=zip_buffer, file_name='frames.zip', mime='application/zip')
+        st.header("抽出画面")
+        with st.form("画面"):
+            cols = st.columns(NUM_COLS)
+
+            for i, frame in enumerate(distinct_frames):
+                with cols[i % NUM_COLS]:
+                    with st.container():
+                        st.image(frame, use_column_width=True, channels='BGR')
+                        if st.checkbox("👆", key=f'frame_{i}'):
+                            selected_frames.append(frame)
+
+            frames_selected = st.form_submit_button("画像ダウンロードの準備")
+
+        # 画面の選択が終わったら、ダウンロードボタンを表示する
+        if frames_selected:
+            if len(selected_frames) > 0:
+                zip_buffer = zip_images(selected_frames)
+                st.download_button(label='⬇️ 選択した画面をまとめてダウンロード', data=zip_buffer, file_name='frames.zip', mime='application/zip')
 
         cv2.destroyAllWindows()
 

--- a/app.py
+++ b/app.py
@@ -65,12 +65,13 @@ def main():
         st.divider()
         # Allow user to download the selected frames as JPEG files
         if len(selected_frames) > 0:
-            zip_buffer = download_images(selected_frames)
+            zip_buffer = zip_images(selected_frames)
             st.download_button(label='⬇️ 選択した画面をまとめてダウンロード', data=zip_buffer, file_name='frames.zip', mime='application/zip')
 
         cv2.destroyAllWindows()
 
-def download_images(frames):
+@st.cache_data
+def zip_images(frames):
     # Create a temporary directory to store the frames
     if not os.path.exists(DOWNLOAD_DIR):
         os.makedirs(DOWNLOAD_DIR)
@@ -90,7 +91,6 @@ def download_images(frames):
     shutil.rmtree(DOWNLOAD_DIR)
 
     return zip_buffer.getvalue()
-
 
 if __name__ == '__main__':
     main()

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import logging
 import os
 import cv2
 import numpy.typing as npt
+import streamlit as st
 
 # initialize Python Logger
 logger = logging.getLogger(__name__)
@@ -22,6 +23,7 @@ def save_frame_as_image(output_dir: str, frame: npt.NDArray, n: int) -> None:
     else:
         logger.info(f"Saved file: {file_path}")
 
+@st.cache_data
 def extract_frames_with_diff_edges(frames: list[npt.NDArray], threshold: float = 1) -> list[npt.NDArray]:
     frame_with_diff_edges_inds = [0]
 
@@ -54,6 +56,7 @@ def extract_frames_with_diff_edges(frames: list[npt.NDArray], threshold: float =
 
     return [ frames[int(frame_i)] for frame_i in representative_frame_inds ]
 
+@st.cache_data
 def remove_similar_frames(frames: list[npt.NDArray], threshold: int = 15) -> list[npt.NDArray]:
     transition_frame_inds = []
 


### PR DESCRIPTION
### キャッシュする関数
入力が変わらなければ、出力が変わらない関数を対象
- `extract_frames_with_diff_edges`
- `remove_similar_frames`
- `zip_images`

### キャッシュしない関数(or まだキャッシュしない)
中身の動画違うけど、同じファイル名や、パス名として渡れる可能性があるので、逆に cache してしまうと違う結果が出てしまう
どうやったら、cache するかはこれから考える
- `save_uploaded_file`
- `read_frames_from_video_file`

TODO (別 PR):
- [x] Grid 内に checkbox を入れることができないかを試す
- [x] `st.cache` で余計な処理を省く
- [ ] Parameter を受け取れるようにする
- [ ] Refactor
- [ ] Deploy
- [ ] 他の人に使われないように、ログイン機能？
- [ ] 機密情報を扱わないように、ブラウザ上で処理できるような実装に変える (大規模)