### PR TITLE
Streamlit アプリを EC2 にデプロイするための AWS CodeDeploy の設定ファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ output**/
 *.csv
 .DS_Store
 temp
+**/*.pem

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-python 3.11.2
+python 3.10.6

--- a/appspec.yml
+++ b/appspec.yml
@@ -2,9 +2,7 @@ version: 0.0
 os: linux
 files:
   - source: /
-    destination: /var/www/html/
-  - source: /aws/nginx.conf
-    destination: /etc/nginx/nginx.conf
+    destination: /usr/src/app
 hooks:
   BeforeInstall:
     - location: /aws/scripts/install_dependencies

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,20 @@
+version: 0.0
+os: linux
+files:
+  - source: /
+    destination: /var/www/html/
+  - source: /aws/nginx.conf
+    destination: /etc/nginx/nginx.conf
+hooks:
+  BeforeInstall:
+    - location: /aws/scripts/install_dependencies
+      timeout: 300
+      runas: root
+    - location: /aws/scripts/start_server
+      timeout: 300
+      runas: root
+  ApplicationStop:
+    - location: /aws/scripts/stop_server
+      timeout: 300
+      runas: root
+

--- a/appspec.yml
+++ b/appspec.yml
@@ -8,6 +8,11 @@ hooks:
     - location: /aws/scripts/install_dependencies
       timeout: 300
       runas: root
+  AfterInstall:
+    - location: /aws/scripts/install_python_dependencies
+      timeout: 300
+      runas: root
+  ApplicationStart:
     - location: /aws/scripts/start_server
       timeout: 300
       runas: root

--- a/appspec.yml
+++ b/appspec.yml
@@ -2,7 +2,7 @@ version: 0.0
 os: linux
 files:
   - source: /
-    destination: /usr/src/app
+    destination: /usr/src/app # デプロイの前に /usr/src/app を作成しておく
 hooks:
   BeforeInstall:
     - location: /aws/scripts/install_dependencies

--- a/aws/CodeDeployEC2Permissions.json
+++ b/aws/CodeDeployEC2Permissions.json
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "s3:Get*",
+                "s3:List*"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::aws-codedeploy-ap-northeast-1/*",
+                "arn:aws:s3:::aws-codedeploy-ap-northeast-2/*"
+            ]
+        }
+    ]
+}

--- a/aws/CodeDeployEC2Role.json
+++ b/aws/CodeDeployEC2Role.json
@@ -1,0 +1,13 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ec2.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}

--- a/aws/CodeDeployServiceRole.json
+++ b/aws/CodeDeployServiceRole.json
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": [
+                    "codedeploy.ap-northeast-1.amazonaws.com",
+                    "codedeploy.ap-northeast-2.amazonaws.com"
+                ]
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}

--- a/aws/scripts/install_dependencies
+++ b/aws/scripts/install_dependencies
@@ -2,7 +2,3 @@
 apt-get install -y python3-pip
 # https://docs.opencv.org/4.x/d2/de6/tutorial_py_setup_in_ubuntu.htmlk
 apt-get install python3-opencv
-
-# need to install streamlit with sudo since application is run with sudo
-cd /usr/src/app || exit
-pip3 install -r requirements.txt

--- a/aws/scripts/install_dependencies
+++ b/aws/scripts/install_dependencies
@@ -1,0 +1,13 @@
+#!/bin/bash
+yum update -y
+
+# nginx conf
+yum install -y nginx
+
+# install pip
+yum install -y python-pip
+
+# install python dependencies
+pip3 install --upgrade pip
+cd /var/www/html/ || exit
+pip3 install -r requirements.txt

--- a/aws/scripts/install_dependencies
+++ b/aws/scripts/install_dependencies
@@ -1,13 +1,8 @@
 #!/bin/bash
-yum update -y
+apt-get install -y python3-pip
+# https://docs.opencv.org/4.x/d2/de6/tutorial_py_setup_in_ubuntu.htmlk
+apt-get install python3-opencv
 
-# nginx conf
-yum install -y nginx
-
-# install pip
-yum install -y python-pip
-
-# install python dependencies
-pip3 install --upgrade pip
-cd /var/www/html/ || exit
+# need to install streamlit with sudo since application is run with sudo
+cd /usr/src/app || exit
 pip3 install -r requirements.txt

--- a/aws/scripts/install_python_dependencies
+++ b/aws/scripts/install_python_dependencies
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd /usr/src/app || exit
+pip3 install -r requirements.txt

--- a/aws/scripts/start_server
+++ b/aws/scripts/start_server
@@ -1,7 +1,4 @@
 #!/bin/bash
 
 # start streamlit
-python3 -m streamlit run app.py --server.port 8080
-
-# start nginx
-service nginx start
+python3 -m streamlit run app.py --server.port 80

--- a/aws/scripts/start_server
+++ b/aws/scripts/start_server
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# start streamlit
+python3 -m streamlit run app.py --server.port 8080
+
+# start nginx
+service nginx start

--- a/aws/scripts/start_server
+++ b/aws/scripts/start_server
@@ -1,4 +1,3 @@
 #!/bin/bash
-
-# start streamlit
+cd /usr/src/app || exit
 python3 -m streamlit run app.py --server.port 80

--- a/aws/scripts/start_server
+++ b/aws/scripts/start_server
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd /usr/src/app || exit
-python3 -m streamlit run app.py --server.port 80
+python3 -m streamlit run app.py --server.port 80 > /dev/null 2> /dev/null < /dev/null &

--- a/aws/scripts/stop_server
+++ b/aws/scripts/stop_server
@@ -1,8 +1,4 @@
 #!/bin/bash
-if [[ -n  $(pgrep nginx) ]]; then
-    pkill -9 nginx
-fi
-
 if [[ -n $(pgrep python3) ]]; then
     pkill -9 python3
 fi

--- a/aws/scripts/stop_server
+++ b/aws/scripts/stop_server
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ -n  $(pgrep nginx) ]]; then
+    pkill -9 nginx
+fi
+
+if [[ -n $(pgrep python3) ]]; then
+    pkill -9 python3
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
+wheel==0.40.0
 opencv-python==4.7.0.72
-pip==23.0.1
 pipdeptree==2.7.0
 scikit-image==0.20.0
-setuptools==65.5.1
-wheel==0.40.0
 streamlit==1.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-wheel==0.40.0
-opencv-python==4.7.0.72
 pipdeptree==2.7.0
-scikit-image==0.20.0
+opencv-python==4.7.0.72
 streamlit==1.21.0


### PR DESCRIPTION
## 概要
- Python のバージョン (合わせた方がパッケージの整合性によるエラーを避けられる)
- AWS EC2 の OS の選択は大事、OpenCV を使うアプリケーションなので、OS の package manager で必要なライブラリをインストールできる OS の方がよかった
  - 最初は AWS Linux 2 で試したけど、OpenCV をインストールしようとしたら、自分でビルドしないといけない
  - なので、Ubuntu に変えた

## 注意
- まだ使い物にならない
  - 今の instance type だと 14.4MB の動画も処理できていないので、instance type を変えるか、アプリケーションの処理を変えるか
- AWS EC2 arm64 では `codedeploy-agent` という service がインストールできないので、x86 のインスタンスが必要
  - 調べたけど、未解決みたい

## 補足
新しいバージョンをデプロイしたいときのコマンド
```sh
aws deploy create-deployment \
--application-name UniqueFramesFromVideo \
--deployment-group-name UniqueFramesFromVideoDeploymentGroup \
--description "<説明>" \
--github-location repository=<ユーザー名/レポジトリ名>,commitId=<フルのコミットハッシュ>
```
`main` にマージしたら、GitHub Action 側でこのコマンドを実行するのもあり